### PR TITLE
Allow passing options to package resource

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,3 +12,4 @@
 default['splunkforwarder']['download_url'] = 'http://download.splunk.com/releases'
 default['splunkforwarder']['build'] = '140868'
 default['splunkforwarder']['version'] = '5.0'
+default['splunkforwarder']['install_options'] = ''

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,5 @@
-version '1.0.0'
+name    'splunkforwarder'
+version '1.0.1'
 
 description 'Installs & Configures Splunk Forwarder'
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -80,8 +80,10 @@ end
 package package_name do
   case node['platform']
   when 'centos', 'redhat', 'fedora'
+    options node['splunkforwarder']['install_options']
     provider Chef::Provider::Package::Rpm
   when 'debian', 'ubuntu'
+    options node['splunkforwarder']['install_options']
     provider Chef::Provider::Package::Dpkg
   end
 


### PR DESCRIPTION
The splunkforwarder rpm is relocatable but the cookbook doesn't allow us to set this currently as it doesn't have a reference to the package 'options' attribute.  This adds it per http://docs.opscode.com/resource_package.html.  We are utilizing this functionality in our fork with:

['splunkforwarder']['install_options'] = "--allfiles --relocate /opt=/opt/apps/ms"
